### PR TITLE
Fix incorrect display share block on mobiles

### DIFF
--- a/src/core/share/ShareLink.js
+++ b/src/core/share/ShareLink.js
@@ -28,12 +28,6 @@ const Link = styled.a`
         }
     }
 
-    @media ${mq.small} {
-        top: 0;
-        left: 0;
-        position: absolute;
-    }
-
     .ShareBlock & {
         transition: all 500ms cubic-bezier(0.87, -0.41, 0.19, 1.44);
         opacity: 0;


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/4408379/100476944-0347ec80-30f8-11eb-9325-953b7aad2ac5.png)

After:
![image](https://user-images.githubusercontent.com/4408379/100476923-f1664980-30f7-11eb-8d36-b2eba291e115.png)

cc @SachaG 