### PR TITLE
Use absolute unit for tooltip arrow position

### DIFF
--- a/src/core/blocks/block/BlockCompletionIndicator.js
+++ b/src/core/blocks/block/BlockCompletionIndicator.js
@@ -59,7 +59,7 @@ const Tooltip = styled.div`
     color: ${color('background')};
 
     &:after {
-        top: 99%;
+        bottom: -15px;
         left: 50%;
         content: ' ';
         height: 0;


### PR DESCRIPTION
Apparently, the percentage arrow position in the tooltip  causing visual bug as barely noticeable border (which is not looks good). This is relevant for Chrome, because I don't see such rendering bug in Firefox. But I believe it's better to use absolute units to achieve consistency in all browsers.

![image](https://user-images.githubusercontent.com/4408379/100478611-c6322900-30fc-11eb-9fbd-3a0377f934d1.png)


On a larger scale, this is especially noticeable:

![image](https://user-images.githubusercontent.com/4408379/100478375-1066da80-30fc-11eb-9de3-7a0d739a03f3.png)

* * *

After that applying this fix:

![image](https://user-images.githubusercontent.com/4408379/100478658-e95cd880-30fc-11eb-80cc-7fdcbb3075d9.png)

cc @SachaG 

