### PR TITLE
Remove untranslatable word from award text for sharing

### DIFF
--- a/src/core/blocks/awards/AwardBlock.js
+++ b/src/core/blocks/awards/AwardBlock.js
@@ -73,7 +73,7 @@ const AwardBlock = ({ block }) => {
                     })}
                 />
                 <ShareBlock
-                    title={`${translate(`award.${type}.title`)} Award`}
+                    title={`${translate(`award.${type}.title`)}`}
                     block={block}
                     className="Award__Share"
                 />


### PR DESCRIPTION
I actually think that we can safely remove this without adding new translation strings.

Current text for sharing:

```
#StateOfCSS 2020: Самая применяемая возможность Award https://2020.stateofcss.com/ru-RU/awards/feature_adoption_delta_award 
```

Or should we still add new strings specially for sharing text of award?

cc @SachaG 