### PR TITLE
Fix display of completion indicator on Firefox

### DIFF
--- a/src/core/blocks/block/BlockCompletionIndicator.js
+++ b/src/core/blocks/block/BlockCompletionIndicator.js
@@ -29,7 +29,7 @@ const BlockCompletionIndicator = ({ completion, variant = 'pink' }) => {
                     cy="10"
                     fill="transparent"
                     strokeWidth="10"
-                    strokeDasharray={`calc(${completion.percentage} * 31.4 / 100) 31.4`}
+                    strokeDasharray={`calc(${completion.percentage} * 31.4px / 100) 31.4px`}
                     transform="rotate(-90) translate(-20)"
                 />
             </Chart>


### PR DESCRIPTION
See https://stackoverflow.com/questions/63504745/svg-pie-chart-working-only-in-chrome-not-in-firefox for more details.

Before:

![2020-11-30_02-12](https://user-images.githubusercontent.com/4408379/100556213-cb84a480-32b1-11eb-8176-9dac0e56bd9e.png)



After:

![2020-11-30_02-11](https://user-images.githubusercontent.com/4408379/100556210-c9bae100-32b1-11eb-8f2d-1cd7c068404b.png)


cc @SachaG 