### PR TITLE
Rearrange footer links to more readability

### DIFF
--- a/src/core/pages/PageFooter.js
+++ b/src/core/pages/PageFooter.js
@@ -43,18 +43,20 @@ const PageFooter = () => {
             </Nav>
             <Notes>
                 <T k="general.charts_nivo" values={{ link: 'https://nivo.rocks/' }} html={true} />{' '}
-                <T k="general.leave_issue" values={{ link: config.issuesUrl }} html={true} />{' '}
-                <T k="general.join_discord" values={{ link: config.discordUrl }} html={true} />{' '}
-                {context.locale.id !== 'en-US' && (
-                    <>
-                        <T k="general.translator_mode" />{' '}
-                    </>
-                )}
                 <T
                     k="general.netlify_link"
                     values={{ link: 'https://www.netlify.com' }}
                     html={true}
                 />
+                <br />
+                <T k="general.leave_issue" values={{ link: config.issuesUrl }} html={true} />{' '}
+                <T k="general.join_discord" values={{ link: config.discordUrl }} html={true} />
+                {context.locale.id !== 'en-US' && (
+                    <>
+                        <br />
+                        <T k="general.translator_mode" />{' '}
+                    </>
+                )}
             </Notes>
         </Container>
     )


### PR DESCRIPTION


In footer there is an additional note for translators that stretch the footer too much:

![image](https://user-images.githubusercontent.com/4408379/100556998-1fde5300-32b7-11eb-804f-71bf2771f322.png)

As a result, we have a messed-up footer, it is difficult to navigate in it, so I propose to split it by adding new lines.


English version will look like this (it has become much cleaner):

![image](https://user-images.githubusercontent.com/4408379/100556989-13f29100-32b7-11eb-9fd2-cdad8367e0da.png)

cc @SachaG 