### PR TITLE
Fix incorrect display site share block on mobiles - 2

### DIFF
--- a/src/core/share/ShareLink.js
+++ b/src/core/share/ShareLink.js
@@ -28,6 +28,12 @@ const Link = styled.a`
         }
     }
 
+    @media ${mq.small} {
+        top: 0;
+        left: 0;
+        position: absolute;
+    }
+
     .ShareBlock & {
         transition: all 500ms cubic-bezier(0.87, -0.41, 0.19, 1.44);
         opacity: 0;
@@ -116,6 +122,10 @@ const Link = styled.a`
             margin: 0 auto;
             height: 24px;
             width: 24px;
+        }
+
+        @media ${mq.small} {
+            position: relative;
         }
     }
 `

--- a/src/core/share/ShareLink.js
+++ b/src/core/share/ShareLink.js
@@ -125,7 +125,7 @@ const Link = styled.a`
         }
 
         @media ${mq.small} {
-            position: relative;
+            position: static;
         }
     }
 `


### PR DESCRIPTION
Follow-up of #15 because we need to reset the position of share block that are only in the sidebar (i.e. ShareSite).

The previously removed code is needed to correctly display the share block in heading. Otherwise we gets follow result (current):

![image](https://user-images.githubusercontent.com/4408379/100558449-8e271380-32bf-11eb-86cf-e98342b855f5.png)

cc @SachaG 
