### PR TITLE
Fix vertical center align of award icons in Firefox

### DIFF
--- a/src/core/blocks/awards/AwardIcon.js
+++ b/src/core/blocks/awards/AwardIcon.js
@@ -16,7 +16,7 @@ export const AwardIcon2 = () => (
                 <path d="M349.396 193.071L476.72 320.395L349.396 447.72L222.071 320.395L349.396 193.071Z" />
             </g>
             <g className="fg">
-                <text x="50%" y="50%" textAnchor="middle" alignmentBaseline="middle">
+                <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle">
                     ?
                 </text>
             </g>


### PR DESCRIPTION
This affects Firefox, for example, nothing changes in Chrome (since vertical alignment works fine there).

Before:

![image](https://user-images.githubusercontent.com/4408379/100620536-93bc4200-332f-11eb-9ef9-6db0f3e8b61d.png)


After:

![image](https://user-images.githubusercontent.com/4408379/100620592-a2a2f480-332f-11eb-9ce5-f24e8b47c731.png)

cc @SachaG 
