### PR TITLE
Fix double border in share link

### DIFF
--- a/src/core/share/ShareLink.js
+++ b/src/core/share/ShareLink.js
@@ -111,7 +111,10 @@ const Link = styled.a`
         flex-grow: 1;
         text-align: center;
         padding: ${spacing()} ${spacing(0.33)};
-        border-right: ${({ theme }) => theme.separationBorder};
+
+        &:not(:last-child) {
+            border-right: ${({ theme }) => theme.separationBorder};
+        }
 
         &:hover {
             background: ${({ theme }) => theme.colors.backgroundAlt};


### PR DESCRIPTION
The share links in the sidebar has an annoying double border:
![image](https://user-images.githubusercontent.com/1894119/101047545-353ad200-3582-11eb-9562-feeba1ddd60f.png)

This PR fixes that issue:
![image](https://user-images.githubusercontent.com/1894119/101047705-54d1fa80-3582-11eb-8d94-2a0e582c3151.png)
