### PR TITLE
Allow button text to wrap

### DIFF
--- a/src/core/components/Button.js
+++ b/src/core/components/Button.js
@@ -11,7 +11,6 @@ const Button = styled.div.attrs(({ className, size = 'medium', variant = 'defaul
     cursor: pointer;
     display: block;
     text-align: center;
-    white-space: nowrap;
     font-weight: ${fontWeight('bold')};
     border: 1px dashed;
     box-shadow: 0 0 0 rgba(0, 0, 0, 0);


### PR DESCRIPTION
To avoid issues like this, especially relevant for translated texts:

![image](https://user-images.githubusercontent.com/4408379/101212550-f7c16c00-3689-11eb-909d-09d5b73a05f4.png)



cc @SachaG 