### PR TITLE
remove Radium

### DIFF
--- a/config/raw_sitemap.yml
+++ b/config/raw_sitemap.yml
@@ -100,7 +100,7 @@
 
       - items: [fm-homepage]
         template: recommendedResourcesTemplate
-        
+
 #- id: overview
 #  path: /overview
 #  blocks:
@@ -128,7 +128,7 @@
 
       - items: [fm-learncss]
         template: recommendedResourcesTemplate
-        
+
   children:
       - id: layout
         path: /layout
@@ -512,8 +512,6 @@
             - id: jss
               template: toolExperienceTemplate
             - id: styled_jsx
-              template: toolExperienceTemplate
-            - id: radium
               template: toolExperienceTemplate
             - id: emotion
               template: toolExperienceTemplate

--- a/config/variables.yml
+++ b/config/variables.yml
@@ -141,7 +141,6 @@ allTools:
     - styled_components
     - jss
     - styled_jsx
-    - radium
     - emotion
     - css_modules
     - styled_system
@@ -182,7 +181,6 @@ toolsCategories:
         - styled_components
         - jss
         - styled_jsx
-        - radium
         - emotion
         - css_modules
         - styled_system

--- a/src/core/charts/tools/ToolsScatterplotChart.js
+++ b/src/core/charts/tools/ToolsScatterplotChart.js
@@ -29,7 +29,6 @@ const labelPositions = {
         Less: [-55, 0],
         JSS: [0, 10],
         SMACSS: [-70, 0],
-        Radium: [-70, 0],
         Bulma: [0, 5],
         Styletron: [0, 5],
         Fela: [-55, 0],


### PR DESCRIPTION
Hi there, I'm the Director of Open Source at Formidable (authors of Radium), and I'd like to ask that Radium be removed from this year's State of CSS report. We put Radium [into maintenance mode](https://formidable.com/blog/2019/radium-maintenance/) over a year ago, and we have no plans modernize it. It's still getting a lot of legacy downloads, but it's not something folks should be considering for new projects. Thanks!